### PR TITLE
Added in the INITIATE_STREAM and COMPLETE_STREAM as standard events

### DIFF
--- a/source/libs/BranchSdkLibrary.brs
+++ b/source/libs/BranchSdkLibrary.brs
@@ -79,6 +79,8 @@ function BranchSdkConstants() as object
         LOGIN:                  "LOGIN",
         SUBSCRIBE:              "SUBSCRIBE",
         START_TRIAL:            "START_TRIAL",
+        INITIATE_STREAM:        "INITIATE_STREAM",
+        COMPLETE_STREAM:        "COMPLETE_STREAM",
         OTHER:                  "OTHER"
     }
 


### PR DESCRIPTION
Added in these two missing events that the customer was requesting. Just had to add them to the constants as now they will hit the code to send them to the standard events endpoint instead of the custom events endpoint. 

![Screenshot 2024-11-15 at 2 50 12 PM](https://github.com/user-attachments/assets/4a14107a-4887-4190-b852-3f9cf3d98ec6)